### PR TITLE
Update connection.json to avoid pointing to not yet existent entities

### DIFF
--- a/connection.json
+++ b/connection.json
@@ -1,9 +1,5 @@
 {
     "account"   : "<your account identifier here>",
     "user"      : "<your user here>",
-    "password"  : "<your_password_here>",
-    "role"      : "FS_QS_ROLE",
-    "warehouse" : "TPCXAI_SF0001_WH",
-    "database"  : "TPCXAI_SF0001_QUICKSTART_INC",
-    "schema"    : "CONFIG"
+    "password"  : "<your_password_here>"
 }


### PR DESCRIPTION
Right now the connection.json in the repo uses a role/warehouse/database/schema that don't actually get created until after the user successfully connects to snowflake in their notebook. Taking out the role/warehouse/database/schema seems to fix this and then in the next few code blocks after connecting, these all get created and explicitly set.